### PR TITLE
Feature: device choice

### DIFF
--- a/CSoundKeeper.cpp
+++ b/CSoundKeeper.cpp
@@ -59,7 +59,6 @@ uint32_t GetSecondsToSleeping()
 
 #include <powrprof.h>
 #include <functiondiscoverykeys_devpkey.h> // for PKEY_Device_FriendlyName
-#include <shellapi.h> // for CommandLineToArgvW
 
 HMODULE GetPowrProfDll()
 {

--- a/CSoundKeeper.cpp
+++ b/CSoundKeeper.cpp
@@ -58,6 +58,8 @@ uint32_t GetSecondsToSleeping()
 // ---------------------------------------------------------------------------------------------------------------------
 
 #include <powrprof.h>
+#include <functiondiscoverykeys_devpkey.h> // for PKEY_Device_FriendlyName
+#include <shellapi.h> // for CommandLineToArgvW
 
 HMODULE GetPowrProfDll()
 {
@@ -427,6 +429,73 @@ uint32_t GetDeviceFormFactor(IMMDevice* device)
 	return formfactor;
 }
 
+//
+// Returns true if the device's friendly name (as shown in mmsys.cpl) contains 'name_filter' as a case-insensitive substring.
+//
+
+bool DeviceNameMatches(IMMDevice* device, const char* name_filter)
+{
+	if (!name_filter || !name_filter[0]) { DebugLog("Device name not set, all devices will be rejected"); return false; }
+
+	IPropertyStore* properties = nullptr;
+	HRESULT hr = device->OpenPropertyStore(STGM_READ, &properties);
+	if (FAILED(hr)) { DebugLog("Failed to check device information"); return false; }
+	defer [&] { properties->Release(); };
+
+	PROPVARIANT prop_name;
+	PropVariantInit(&prop_name);
+	//
+	// Friendly name contains both the device name that the user can change
+	// and the device's own name as specified in the driver or wherever it
+	// is specified.
+	// For example, if I rename a device into "CABLE Input", and the device's name
+	// itself is "VB-Audio Virtual Cable", Friendly name would be:
+	// "CABLE Input (VB-Audio Virtual Cable)".
+	// This may obviously exceed MAX_AUDIODEVICENAME_LENGTH which I specified to
+	// be 41 in BasicDefines.hpp. However, this shouldn't be a problem because
+	// the user-renamable name comes first and I used safe functions limited by
+	// length correctly, and matching is done by looking for a substring (strstr).
+	//
+	hr = properties->GetValue(PKEY_Device_FriendlyName, &prop_name);
+	int vt = prop_name.vt;
+	if (FAILED(hr) || vt != VT_LPWSTR)
+	{
+		PropVariantClear(&prop_name);
+		DebugLog("Failed to get audio device friendly name, prop vt was: %d", vt);
+		return false;
+	}
+
+	// both sides to lower
+	wchar_t wdevice_lower[MAX_AUDIODEVICENAME_LENGTH];
+	wcsncpy_s(wdevice_lower, prop_name.pwszVal, MAX_AUDIODEVICENAME_LENGTH - 1);
+	_wcslwr_s(wdevice_lower, MAX_AUDIODEVICENAME_LENGTH);
+	char device_lower[MAX_AUDIODEVICENAME_LENGTH];
+	//
+	// Audio device names are stored in wide characters. However the rest of
+	// the source code does not support wide characters. I've decided to not
+	// add support for it as that would be too much changes.
+	// Instead the user is expected to rename their audio devices in mmsys.cpl.
+	// Unicode characters in audio device names will be treated as '\n' because
+	// it's pretty hard to use a newline in a command-line argument and even
+	// more so in the file name. Therefore such a name will never be able to be
+	// matched. Hopefully this will force the user to read the readme and see
+	// that they are advised to rename their audio devices to not contain any
+	// unicode characters.
+	//
+	char replacementchar = '\n';
+	WideCharToMultiByte(CP_ACP, 0, wdevice_lower, -1, device_lower, sizeof(device_lower), &replacementchar, NULL);
+
+	char filter_lower[MAX_AUDIODEVICENAME_LENGTH];
+	strncpy_s(filter_lower, name_filter, MAX_AUDIODEVICENAME_LENGTH - 1);
+	_strlwr_s(filter_lower, MAX_AUDIODEVICENAME_LENGTH);
+
+	bool match = (strstr(device_lower, filter_lower) != nullptr);
+	DebugLog("Match=%s: Current FriendlyName: '%s'; Filter: '%s'", match ? "yes" : "no", device_lower, filter_lower);
+
+	PropVariantClear(&prop_name);
+	return match;
+}
+
 HRESULT CSoundKeeper::Start()
 {
 	ScopedLock lock(m_mutex);
@@ -525,6 +594,12 @@ HRESULT CSoundKeeper::Start()
 				&& (m_cfg_device_type == KeepDeviceType::Digital) != (formfactor == SPDIF || formfactor == HDMI))
 			{
 				DebugLog("Skipping this device because of the Digital / Analog filter.");
+				continue;
+			}
+			else if (m_cfg_device_type == KeepDeviceType::ByName
+				&& !DeviceNameMatches(device, m_cfg_device_name))
+			{
+				DebugLog("Skipping this device, the device name doesn't match the specified filter: %s", m_cfg_device_name);
 				continue;
 			}
 
@@ -903,6 +978,21 @@ void CSoundKeeper::ParseModeString(const char* args)
 	if (strstr(buf, "all"))     { this->SetDeviceType(KeepDeviceType::All); }
 	if (strstr(buf, "analog"))  { this->SetDeviceType(KeepDeviceType::Analog); }
 	if (strstr(buf, "digital")) { this->SetDeviceType(KeepDeviceType::Digital); }
+	if (const char* p = strstr(buf, "device"))
+	{
+		p += 6;
+
+		const char* charlimit = p + MAX_AUDIODEVICENAME_LENGTH + 1;
+		if (*p == ' ' || *p == '\t' || *p == '-' || *p == '=') { p++; }
+		const char* end = p;
+		do { end++; } while (*end && *end != ';' && end < charlimit);
+
+		char devicename[MAX_AUDIODEVICENAME_LENGTH];
+		strncpy_s(devicename, p, end - p);
+
+		this->SetDeviceName(devicename);
+		this->SetDeviceType(KeepDeviceType::ByName);
+	}
 	if (strstr(buf, "kill"))    { this->SetDeviceType(KeepDeviceType::None); }
 	if (strstr(buf, "remote"))  { this->SetAllowRemote(true); }
 

--- a/CSoundKeeper.hpp
+++ b/CSoundKeeper.hpp
@@ -5,7 +5,7 @@
 #include <mmdeviceapi.h>
 #include <audiopolicy.h>
 
-enum class KeepDeviceType { None, Primary, Digital, Analog, All };
+enum class KeepDeviceType { None, Primary, Digital, Analog, All, ByName };
 enum class KeepStreamType { None, Zero, Fluctuate, Sine, WhiteNoise, BrownNoise, PinkNoise };
 
 class CSoundKeeper;
@@ -58,6 +58,7 @@ protected:
 	bool                    m_cfg_sleep_with_display = false;
 	bool                    m_cfg_sleep_with_user_lock = false;
 	KeepDeviceType          m_cfg_device_type = KeepDeviceType::Primary;
+	char                    m_cfg_device_name[MAX_AUDIODEVICENAME_LENGTH] = "";
 	KeepStreamType          m_cfg_stream_type = KeepStreamType::Zero;
 	double                  m_cfg_frequency = 0.0;
 	double                  m_cfg_amplitude = 0.0;
@@ -80,6 +81,17 @@ protected:
 public:
 
 	void SetDeviceType(KeepDeviceType device_type) { m_cfg_device_type = device_type; }
+	void SetDeviceName(const char* name)
+	{
+		if (name && name[0])
+		{
+			strncpy_s(m_cfg_device_name, name, MAX_AUDIODEVICENAME_LENGTH - 1);
+		}
+		else
+		{
+			m_cfg_device_name[0] = '\0';
+		}
+	}
 	void SetStreamType(KeepStreamType stream_type) { m_cfg_stream_type = stream_type; }
 	void SetAllowRemote(bool allow) { m_cfg_allow_remote = allow; }
 	void SetSleepWithIdleTimer(bool value) { m_cfg_sleep_with_idle_timer = value; }
@@ -87,6 +99,7 @@ public:
 	void SetSleepWithDisplay(bool value) { m_cfg_sleep_with_display = value; }
 	void SetSleepWithUserLock(bool value) { m_cfg_sleep_with_user_lock = value; }
 	KeepDeviceType GetDeviceType() const { return m_cfg_device_type; }
+	const char* GetDeviceName() const { return m_cfg_device_name; }
 	KeepStreamType GetStreamType() const { return m_cfg_stream_type; }
 	bool GetAllowRemote() const { return m_cfg_allow_remote; }
 	bool GetSleepWithIdleTimer() const { return m_cfg_sleep_with_idle_timer; }

--- a/Common/BasicDefines.hpp
+++ b/Common/BasicDefines.hpp
@@ -105,3 +105,5 @@
 #else
 	#define IS_INTELLISENSE 0
 #endif
+
+#define MAX_AUDIODEVICENAME_LENGTH 42 // the character limit for device names in mmsys.cpl is 41

--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -20,6 +20,14 @@ Supported device type settings:
 - "All" keeps on all enabled audio outputs.
 - "Digital" keeps on all enabled SPDIF and HDMI audio outputs (like it was in Sound Keeper v1.0).
 - "Analog" keeps on all enabled audio outputs except SPDIF and HDMI.
+- "Device" keeps on all outputs that match the audio device name chosen by the user.
+
+The "ByName" type requires some more explanation. On Windows it's possible to rename audio devices.
+To do that, you can open the legacy "Sounds" dialog (Win+R -> mmsys.cpl), open properties of any
+audio device and simply modify the name and click apply. You can then pass that name to SoundKeeper
+either as an argument or in the file name itself just like all other options.
+The syntax is "DeviceDEVICE NAME;".
+Please don't have semicolons in your device name. (but it might still work)
 
 Supported stream type settings:
 - "OpenOnly" opens audio output, but doesn't play anything. Sometimes it helps.
@@ -47,6 +55,7 @@ Examples:
 - SoundKeeperSineF1000A15.exe generates 1000Hz sine wave with 15% amplitude. It is audible! Use it for testing.
 - "SoundKeeper.exe sine -f 1000 -a 15" is a command line version of the previous example.
 - "SoundKeeper.exe brown -a 0.1" (settings are command line arguments) generates brown noise with 0.1% amplitude.
+- "SoundKeeperDeviceCABLE Input;SineF440A10.exe" generates an audible sine wave on device named "CABLE Input".
 
 What's new
 


### PR DESCRIPTION
Hello! This pull request adds a feature to allow device choice by name, instead of just "all digital", "all analog" or "all". I personally needed it so I made it.

I am unfortunately still very new to C++ so I am not ready to say that this code is perfect or good even. If you don't have the time to check it, feel free to decline this pull request.

What this does: allows the user to specify the device to work with. Multiple devices can match if they both contain the substring specified by the user. The syntax is "device" and then the device name until ';', for example: "SoundKeeperDeviceCABLE Input;SineF440A10.exe"

What changed:
- New KeepDeviceType: "ByName"
- New field which stores user's device choice (and a getter/setter for it)
- New available launch parameter: "device"; parsed AFTER all other modes (all, analog, digital) but BEFORE "kill"
- Added methods and modified some methods to make the feature work (added parsing logic)
- Updated readme

There are some more questionable things in the code comments.
I tried to preserve the original logic as much as possible though.

I tested it and the feature works and doesn't seem to break anything but I didn't fully test it. Tested it with command-line arguments too, not just with file renaming.